### PR TITLE
feat: warm auth tokens in client layout

### DIFF
--- a/src/app/client/layout.tsx
+++ b/src/app/client/layout.tsx
@@ -3,8 +3,11 @@
 import "@/app/globals.css";
 import RequireAuth from "@/components/auth/RequireAuth";
 import { SidebarSection } from "@/components/SidebarSection";
+import { useFocusWarmAuth } from "@/lib/supabase/safe";
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
+  useFocusWarmAuth();
+
   return (
     <RequireAuth>
       <div className="flex items-start relative bg-coolgray-10 w-full min-h-screen">


### PR DESCRIPTION
## Summary
- refresh auth tokens on focus/visibility for client layout

## Testing
- `npm test`
- `npm run lint` *(fails: 'response' is never reassigned. Use 'const' instead. prefer-const)*

------
https://chatgpt.com/codex/tasks/task_e_689afa93d210832f9fef33e87a19eb81